### PR TITLE
Improve the code quality

### DIFF
--- a/src/main/java/duke/Commands.java
+++ b/src/main/java/duke/Commands.java
@@ -44,6 +44,7 @@ class AddTodoCommand extends AddTaskCommand {
         super(argument);
     }
 
+    @Override
     public Task parseTask(String argument) throws InvalidCommandException {
         if (argument.isEmpty()) {
             throw new InvalidCommandException("The description of a todo cannot be empty.");
@@ -57,6 +58,7 @@ class AddDeadlineCommand extends AddTaskCommand {
         super(argument);
     }
 
+    @Override
     public Task parseTask(String argument) throws InvalidCommandException {
         String[] parts = argument.split(" /by ", 2);
         if (parts.length != 2) {
@@ -79,6 +81,7 @@ class AddEventCommand extends AddTaskCommand {
 
     private static final Pattern EVENT_PATTERN = Pattern.compile("(.*) /from (.*) /to (.*)");
 
+    @Override
     public Task parseTask(String argument) throws InvalidCommandException {
         Matcher matcher = EVENT_PATTERN.matcher(argument);
         if (!matcher.matches()) {

--- a/src/main/java/duke/Event.java
+++ b/src/main/java/duke/Event.java
@@ -8,17 +8,19 @@ import java.time.LocalDateTime;
 public class Event extends Task {
     protected LocalDateTime from, to;
 
-    public Event (String description, String from, String to) {
+    public Event(String description, String from, String to) {
         super(description);
         this.from = LocalDateTime.parse(from, Constants.INPUT_FORMATTER);
         this.to = LocalDateTime.parse(to, Constants.INPUT_FORMATTER);
     }
 
+    @Override
     public String toString() {
         return "[E]" + super.toString() + " (from: " + from.format(Constants.OUTPUT_FORMATTER)
             + " to: " + to.format(Constants.OUTPUT_FORMATTER) + ")";
     }
 
+    @Override
     public String serializeToCommand(int taskIndex) {
         return "event " + description + " /from " + from.format(Constants.INPUT_FORMATTER)
             + " /to " + to.format(Constants.INPUT_FORMATTER) + "\n" + serializeDoneMark(taskIndex);

--- a/src/main/java/duke/Todo.java
+++ b/src/main/java/duke/Todo.java
@@ -1,10 +1,11 @@
 package duke;
 
 public class Todo extends Task {
-    public Todo (String description) {
+    public Todo(String description) {
         super(description);
     }
 
+    @Override
     public String toString() {
         return "[T]" + super.toString();
     }


### PR DESCRIPTION
Many methods that overrides a method or implements an abstract method in the parent class/interface does not have the @Override annotation.

This is bad coding practice, and does not allow the compiler to raise warnings about incorrect overriding.

This commit changes the situation by adding @Override at various places.