### PR TITLE
Check for clashing tasks and related improvements

### DIFF
--- a/src/main/java/duke/AddTaskResult.java
+++ b/src/main/java/duke/AddTaskResult.java
@@ -1,0 +1,51 @@
+package duke;
+
+/**
+ * Represents the result of adding a task to the task list.
+ */
+public class AddTaskResult {
+    private boolean isSuccessful;
+    private Task clashingTask;
+
+    /**
+     * Constructs a new AddTaskResult object.
+     *
+     * @param isSuccessful Whether the task was successfully added.
+     * @param clashingTask The task that the new task clashes with, if any.
+     */
+    private AddTaskResult(boolean isSuccessful, Task clashingTask) {
+        this.isSuccessful = isSuccessful;
+        this.clashingTask = clashingTask;
+    }
+
+    /**
+     * Returns a new AddTaskResult object representing a successful addition of a task.
+     */
+    public static AddTaskResult buildSuccessfulResult() {
+        return new AddTaskResult(true, null);
+    }
+
+    /**
+     * Returns a new AddTaskResult object representing a failed addition of a task.
+     *
+     * @param clashingTask The task that the new task clashes with.
+     */
+    public static AddTaskResult buildClashingResult(Task clashingTask) {
+        return new AddTaskResult(false, clashingTask);
+    }
+
+    /**
+     * Returns whether the task was successfully added.
+     */
+    public boolean isSuccessful() {
+        return isSuccessful;
+    }
+
+    /**
+     * Returns the task that the new task clashes with, if any.
+     */
+    public Task getClashingTask() {
+        assert !isSuccessful : "There is no clashing task if the addition was successful";
+        return clashingTask;
+    }
+}

--- a/src/main/java/duke/Constants.java
+++ b/src/main/java/duke/Constants.java
@@ -7,7 +7,8 @@ import java.time.format.DateTimeFormatter;
  * This class should not be instantiated.
  */
 public class Constants {
-    public static final DateTimeFormatter INPUT_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+    public static final DateTimeFormatter INPUT_FORMATTER =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
     public static final DateTimeFormatter OUTPUT_FORMATTER =
-        DateTimeFormatter.ofPattern("MMM dd yyyy HH:mm:ss");
+        DateTimeFormatter.ofPattern("MMM dd yyyy HH:mm");
 }

--- a/src/main/java/duke/Deadline.java
+++ b/src/main/java/duke/Deadline.java
@@ -14,6 +14,11 @@ public class Deadline extends Task {
     }
 
     @Override
+    public boolean isClashingWith(Task otherTask) {
+        return false;
+    }
+
+    @Override
     public String toString() {
         return "[D]" + super.toString() + " (by: " + by.format(Constants.OUTPUT_FORMATTER) + ")";
     }

--- a/src/main/java/duke/Event.java
+++ b/src/main/java/duke/Event.java
@@ -6,23 +6,33 @@ import java.time.LocalDateTime;
  * Represents an event task.
  */
 public class Event extends Task {
-    protected LocalDateTime from, to;
+    protected LocalDateTime startingTime, endingTime;
 
-    public Event(String description, String from, String to) {
+    public Event(String description, LocalDateTime startingTime, LocalDateTime endingTime) {
         super(description);
-        this.from = LocalDateTime.parse(from, Constants.INPUT_FORMATTER);
-        this.to = LocalDateTime.parse(to, Constants.INPUT_FORMATTER);
+        this.startingTime = startingTime;
+        this.endingTime = endingTime;
+    }
+
+    @Override
+    public boolean isClashingWith(Task otherTask) {
+        if (otherTask instanceof Event) {
+            Event otherEvent = (Event) otherTask;
+            return this.startingTime.isBefore(otherEvent.endingTime) && this.endingTime.isAfter(otherEvent.startingTime);
+        } else {
+            return false;
+        }
     }
 
     @Override
     public String toString() {
-        return "[E]" + super.toString() + " (from: " + from.format(Constants.OUTPUT_FORMATTER)
-            + " to: " + to.format(Constants.OUTPUT_FORMATTER) + ")";
+        return "[E]" + super.toString() + " (from: " + startingTime.format(Constants.OUTPUT_FORMATTER)
+            + " to: " + endingTime.format(Constants.OUTPUT_FORMATTER) + ")";
     }
 
     @Override
     public String serializeToCommand(int taskIndex) {
-        return "event " + description + " /from " + from.format(Constants.INPUT_FORMATTER)
-            + " /to " + to.format(Constants.INPUT_FORMATTER) + "\n" + serializeDoneMark(taskIndex);
+        return "event " + description + " /from " + startingTime.format(Constants.INPUT_FORMATTER)
+            + " /to " + endingTime.format(Constants.INPUT_FORMATTER) + "\n" + serializeDoneMark(taskIndex);
     }
 }

--- a/src/main/java/duke/Task.java
+++ b/src/main/java/duke/Task.java
@@ -42,10 +42,17 @@ abstract public class Task {
      * then after executing the string representation,
      * there will be taskIndex + 1 tasks in the list.
      *
-     * @param taskIndex the 0-indexed index of this task
-     * @return the serialized string
+     * @param taskIndex the 0-indexed index of this task.
+     * @return the serialized string.
      */
     public abstract String serializeToCommand(int taskIndex);
+
+    /**
+     * Determines if the current task clashes with the other given task.
+     *
+     * @param otherTask the other task.
+     */
+    public abstract boolean isClashingWith(Task otherTask);
 
     protected String serializeDoneMark(int taskIndex) {
         if (this.isDone) {

--- a/src/main/java/duke/TaskList.java
+++ b/src/main/java/duke/TaskList.java
@@ -10,9 +10,17 @@ public class TaskList {
      * Adds a task to the task list.
      *
      * @param task Task to be added.
+     * @return the status of the task addition.
      */
-    public void addTask(Task task) {
+    public AddTaskResult addTask(Task task) {
+        // check if it doesn't clash first
+        for (Task t : tasks) {
+            if (t.isClashingWith(task)) {
+                return AddTaskResult.buildClashingResult(t);
+            }
+        }
         tasks.add(task);
+        return AddTaskResult.buildSuccessfulResult();
     }
 
     /**
@@ -37,8 +45,6 @@ public class TaskList {
 
     /**
      * Returns the number of tasks in the list.
-     *
-     * @return The number of tasks in the list.
      */
     public int getTaskCount() {
         return tasks.size();
@@ -56,7 +62,8 @@ public class TaskList {
         TaskList foundTasks = new TaskList();
         for (Task task : tasks) {
             if (task.getDescription().contains(query)) {
-                foundTasks.addTask(task);
+                AddTaskResult additionResult = foundTasks.addTask(task);
+                assert additionResult.isSuccessful() : "This task list should not have clashing tasks.";
             }
         }
         return foundTasks;

--- a/src/main/java/duke/Todo.java
+++ b/src/main/java/duke/Todo.java
@@ -6,6 +6,11 @@ public class Todo extends Task {
     }
 
     @Override
+    public boolean isClashingWith(Task otherTask) {
+        return false;
+    }
+
+    @Override
     public String toString() {
         return "[T]" + super.toString();
     }


### PR DESCRIPTION
Two clashing events can be added at the same time.

This is bad because the user may accidentally enter the wrong event starting/ending time and not notice it.

Let's,
* check for clashing tasks before adding it
* in the meantime, make sure that the starting time of an event is before the ending time